### PR TITLE
Bugfix: ScrollFollow component doesn't stop following

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazylog",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "React Lazy Logviewer",
   "license": "MPL-2.0",
   "repository": "mozilla-frontend-infra/react-lazylog",

--- a/src/components/ScrollFollow/index.jsx
+++ b/src/components/ScrollFollow/index.jsx
@@ -1,5 +1,5 @@
-import {Component, Fragment} from 'react';
-import {bool, number, func} from 'prop-types';
+import { Component, Fragment } from 'react';
+import { bool, number, func } from 'prop-types';
 
 const MARGIN_TO_BOTTOM_EPSILON = 30;
 
@@ -48,7 +48,7 @@ export default class ScrollFollow extends Component {
 
   static defaultProps = {
     startFollowing: false,
-    marginToBottomEpsilon: MARGIN_TO_BOTTOM_EPSILON
+    marginToBottomEpsilon: MARGIN_TO_BOTTOM_EPSILON,
   };
 
   static getDerivedStateFromProps(nextProps) {
@@ -59,16 +59,19 @@ export default class ScrollFollow extends Component {
 
   state = {
     follow: false,
-    scrollHeight: 0
+    scrollHeight: 0,
   };
 
-  handleScroll = ({scrollTop, scrollHeight, clientHeight}) => {
+  handleScroll = ({ scrollTop, scrollHeight, clientHeight }) => {
     if (this.state.scrollHeight !== scrollHeight) {
-      this.setState(state => ({...state, scrollHeight}))
+      this.setState(state => ({ ...state, scrollHeight }));
     } else {
       const marginToBottom = scrollHeight - scrollTop - clientHeight;
 
-      if (this.state.follow && marginToBottom > this.props.marginToBottomEpsilon) {
+      if (
+        this.state.follow &&
+        marginToBottom > this.props.marginToBottomEpsilon
+      ) {
         this.stopFollowing();
       } else if (
         this.props.startFollowing &&
@@ -81,16 +84,16 @@ export default class ScrollFollow extends Component {
   };
 
   startFollowing = () => {
-    this.setState(state => ({...state, follow: true}));
+    this.setState(state => ({ ...state, follow: true }));
   };
 
   stopFollowing = () => {
-    this.setState(state => ({...state, follow: false}));
+    this.setState(state => ({ ...state, follow: false }));
   };
 
   render() {
-    const {render} = this.props;
-    const {follow} = this.state;
+    const { render } = this.props;
+    const { follow } = this.state;
 
     return (
       <Fragment>

--- a/src/components/ScrollFollow/index.jsx
+++ b/src/components/ScrollFollow/index.jsx
@@ -51,14 +51,8 @@ export default class ScrollFollow extends Component {
     marginToBottomEpsilon: MARGIN_TO_BOTTOM_EPSILON,
   };
 
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      follow: nextProps.startFollowing,
-    };
-  }
-
   state = {
-    follow: false,
+    follow: this.props.startFollowing,
     scrollHeight: 0,
   };
 

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -1,0 +1,42 @@
+import mitt from 'mitt';
+import { List } from 'immutable';
+import { encode } from './encoding';
+import { bufferConcat, convertBufferToLines } from './utils';
+
+export default eventSource => {
+  const emitter = mitt();
+  let overage = null;
+  let encodedLog = new Uint8Array();
+
+  eventSource.on('data', data => {
+    encodedLog = bufferConcat(encodedLog, encode(data));
+
+    const { lines, remaining } = convertBufferToLines(encode(data), overage);
+
+    overage = remaining;
+
+    emitter.emit('update', { lines, encodedLog });
+  });
+
+  eventSource.on('done', () => {
+    if (overage) {
+      emitter.emit('update', { lines: List.of(overage), encodedLog });
+    }
+
+    emitter.emit('end', encodedLog);
+  });
+
+  emitter.on('start', async () => {
+    try {
+      eventSource.emit('start');
+    } catch (err) {
+      emitter.emit('error', err);
+    }
+  });
+
+  emitter.on('abort', () => {
+    eventSource.emit('abort');
+  });
+
+  return emitter;
+};


### PR DESCRIPTION
Bugfix: ScrollFollow component doesn't stop following when the user scroll up despite setting "startFollowing" prop to true.

Feature: ScrollFollow resumes following when the user scroll all the way
down and the "startFollowing" prop is true.